### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,6 +63,12 @@ for a network with proxy.
 
 This will download the SQL files to initalize the cBioPortal database and also initialize the config file for the database.
 
+The application's Docker container are running as `root` user. If you are not the `root` user, you may want to change the permissions of the `data/` directory with e.g.:
+
+```
+sudo chmod 755 data/
+```
+
 ### 4. Starting MTB-cbioportal
 
 Now start MTB-cBioPortal. 


### PR DESCRIPTION
I got an error when starting the containers stating that the file tumorTypes.json cannot be read because of the permission was denied. This can be solved by changing the ownership of the directory or setting the appropriate permissions for these files.